### PR TITLE
Add persistent cache volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,5 +17,9 @@ services:
       - /etc/spotifyd.conf:/etc/spotifyd.conf
       - /etc/asound.conf:/etc/asound.conf
       - /run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
+      - cache:/cache
     group_add:
       - 2001
+
+volumes:
+  cache:


### PR DESCRIPTION
To make a possible audio cache persistent a named volume need to be added to docker-compose.yml. Even if not enabling audio caching by default that does not hurt and makes enabling it later more easy.