### PR TITLE
Modify dbus-spotifyd.conf to own_prefix instead of own (closes #4)

### DIFF
--- a/dbus-spotifyd.conf
+++ b/dbus-spotifyd.conf
@@ -4,8 +4,7 @@
 
  <!-- Player can own the Spotify service -->
   <policy user="player">
-    <allow own="org.mpris.MediaPlayer2.spotifyd"/>
-    <allow own="org.mpris.MediaPlayer2.spotifyd.instance1" />
+    <allow own_prefix="org.mpris.MediaPlayer2.spotifyd"/>
   </policy>
 
 </busconfig>


### PR DESCRIPTION
This pull request modifies dbus-spotify.conf allowing player to own the prefix org.mpris.MediaPlayer2.spotifyd instead of setting the ownership explicitly to org.mpris.MediaPlayer2.spotifyd and org.mpris.MediaPlayer2.spotifyd.instance1. The instance number appears to increment, which can cause the docker container to fail to start if Metadata and control support is enabled. This fixes #4 